### PR TITLE
deps: upgrade github.com/dolmen-go/mylogin to v1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/capitalone/fpe v1.2.1
 	github.com/denisenkom/go-mssqldb v0.10.0
 	github.com/dnnrly/abbreviate v1.5.2
-	github.com/dolmen-go/mylogin v0.0.0-20211007211255-18ac7793a122
+	github.com/dolmen-go/mylogin v1.0.0
 	github.com/go-ego/gse v0.67.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/google/differential-privacy/go v0.0.0-20210713105217-8da48001ccbd
@@ -29,7 +29,7 @@ require (
 	github.com/pingcap/parser v0.0.0-20210525032559-c37778aff307
 	github.com/pingcap/tidb v1.1.0-beta.0.20210601085537-5d7c852770eb
 	github.com/pingcap/tipb v0.0.0-20210601083426-79a378b6d1c4 // indirect
-	github.com/prestodb/presto-go-client v0.0.0-20211201125635-ad28cec17d6c // indirect
+	github.com/prestodb/presto-go-client v0.0.0-20211201125635-ad28cec17d6c
 	github.com/sijms/go-ora/v2 v2.4.28
 	github.com/taozle/go-hive-driver v0.0.0-20181206100408-79951111cb07
 	github.com/tealeg/xlsx/v3 v3.2.3

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKoh
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/dolmen-go/mylogin v0.0.0-20211007211255-18ac7793a122 h1:vinZkqYdp8klhsJBOGz4V9JNz5GEBLvjcc3i015I30E=
-github.com/dolmen-go/mylogin v0.0.0-20211007211255-18ac7793a122/go.mod h1:EoH138uGURqqDK3ozwLmEG83pv2igAUhzHYL3Z9RKw8=
+github.com/dolmen-go/mylogin v1.0.0 h1:o36Pkyk8QsLc2604UUy1vdSqPJnPGUB1KD/Uri4xsjI=
+github.com/dolmen-go/mylogin v1.0.0/go.mod h1:EoH138uGURqqDK3ozwLmEG83pv2igAUhzHYL3Z9RKw8=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=


### PR DESCRIPTION
Upgrade package [`github.com/dolmen-go/mylogin`](https://pkg.go.dev/github.com/dolmen-go/mylogin):
- major bug fixed in mylogin before v1.0.0: see dolmen-go/mylogin@43b42372944e55c89520c583487f71867c0ed5d2
- use tagged versions now that they exist

Note: I'm the maintainer of the mylogin package.